### PR TITLE
Don't drop extras from parsed VCS packages

### DIFF
--- a/pipcompilemulti/dependency.py
+++ b/pipcompilemulti/dependency.py
@@ -32,7 +32,7 @@ class Dependency(object):
         r'(?iu)(?P<editable>-e)?'
         r'\s*'
         r'(?P<prefix>\S+#egg=)'
-        r'(?P<package>[a-z0-9-_.]+)'
+        r'(?P<package>[^=&\s]+)'
         r'(?P<postfix>\S+)'
         r'\s*'
         r'(?P<comment>#.*)?$'


### PR DESCRIPTION
Compiling two requirements file that specify VCS dependencies that differ only by their extras was broken. The regular expression to match the package name simply ignored everything that was not a valid identifier, but the form `package[extra]` is valid and not the same as `package`.
