### PR TITLE
[fix] Typo in —annotate-index docstring

### DIFF
--- a/pipcompilemulti/features/annotate_index.py
+++ b/pipcompilemulti/features/annotate_index.py
@@ -3,7 +3,7 @@ Add index URL annotation
 ========================
 
 This flag provides the ability to annotate the index URL mimicking the logic of
-the ``pip-compile`` ``--index`` and ``--no-index` flag by opting to add or not
+the ``pip-compile`` ``--index`` and ``--no-index`` flag by opting to add or not
 add the ``pip`` index to the generated files.
 
 .. code-block:: text


### PR DESCRIPTION
This PR adds the missing back-tick which should remedy the document formatting issue [here](https://pip-compile-multi.readthedocs.io/en/latest/features.html#add-index-url-annotation).