### PR TITLE
Use the same Python executable for running pip-tools

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,16 @@
 History
 =======
 
+2.3.1 (2021-02-16)
+------------------
+
+* Fix for a bug introduced in 2.2.2 when running pip-compile-multi
+  installed for Python 3, and having ``python`` symlinked to Python 2.
+  (Issue `#233`_, PR `#234`_).
+
+.. _#233: https://github.com/peterdemin/pip-compile-multi/issues/233
+.. _#234: https://github.com/peterdemin/pip-compile-multi/pull/234
+
 2.3.0 (2021-02-04)
 ------------------
 

--- a/pipcompilemulti/__init__.py
+++ b/pipcompilemulti/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Peter Demin'
 __email__ = 'peterdemin@gmail.com'
-__version__ = '2.3.0'
+__version__ = '2.3.1'

--- a/pipcompilemulti/environment.py
+++ b/pipcompilemulti/environment.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 import logging
 import subprocess
 
@@ -117,8 +118,10 @@ class Environment(object):
     @property
     def pin_command(self):
         """Compose pip-compile shell command"""
+        # Use the same interpreter binary
+        python = sys.executable or 'python'
         parts = [
-            'python', '-m', 'piptools', 'compile',
+            python, '-m', 'piptools', 'compile',
             '--no-header',
             '--verbose',
         ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = "2.3.0"
+VERSION = "2.3.1"
 
 
 README = """


### PR DESCRIPTION
Fixes #233