### PR TITLE
Add verbose flag

### DIFF
--- a/pipcompilemulti/environment.py
+++ b/pipcompilemulti/environment.py
@@ -77,7 +77,8 @@ class Environment(object):
                         break
                     if output:
                         print(output.strip())
-                rc = process.poll()
+                # TODO: Decide what to do about this
+                # stdout, stderr = process.poll(), None
 
             stdout, stderr = process.communicate()
         finally:

--- a/pipcompilemulti/environment.py
+++ b/pipcompilemulti/environment.py
@@ -63,11 +63,22 @@ class Environment(object):
             if sink_out_path and sink_out_path != self.outfile:
                 original_in_file = self._read_infile()
                 self._inject_sink()
+
+            verbose = True
             process = subprocess.Popen(
                 self.pin_command,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=None if verbose else subprocess.PIPE,
             )
+            if verbose:
+                while True:
+                    output = process.stdout.readline()
+                    if output == b'' and process.poll() is not None:
+                        break
+                    if output:
+                        print(output.strip())
+                rc = process.poll()
+
             stdout, stderr = process.communicate()
         finally:
             if original_in_file:

--- a/pipcompilemulti/environment.py
+++ b/pipcompilemulti/environment.py
@@ -67,19 +67,9 @@ class Environment(object):
             verbose = True
             process = subprocess.Popen(
                 self.pin_command,
-                stdout=subprocess.PIPE,
+                stdout=None if verbose else subprocess.PIPE,
                 stderr=None if verbose else subprocess.PIPE,
             )
-            if verbose:
-                while True:
-                    output = process.stdout.readline()
-                    if output == b'' and process.poll() is not None:
-                        break
-                    if output:
-                        print(output.strip())
-                # TODO: Decide what to do about this
-                # stdout, stderr = process.poll(), None
-
             stdout, stderr = process.communicate()
         finally:
             if original_in_file:


### PR DESCRIPTION
Initial sketch of a solution to #153 

These are my changes so far in their entirety (within `environment.py::Environment::create_lockfile()`):

```python
verbose = True
process = subprocess.Popen(
    self.pin_command,
    stdout=subprocess.PIPE,
    stderr=None if verbose else subprocess.PIPE,
)
if verbose:
    while True:
        output = process.stdout.readline()
        if output == b'' and process.poll() is not None:
            break
        if output:
            print(output.strip())
    # TODO: Decide what to do about this
    # stdout, stderr = process.poll(), None
```

I haven't add the CLI argument for `verbose` as I'm not sure of the best way to hook this up;  also I'm not sure if this solution is workable. I've tested it, and it works, but there may be drawbacks from doing this that I'm not aware of and I'm pretty sure that using `print(output.strip())` here isn't correct (should it be `logger.info()` or `sys.stdout.write()` maybe?).

Hopefully it's a starting point though?

It's passing `flake8` and I've run pytest:

```
ERROR    pip-compile-multi:environment.py:218 Package django was resolved to different versions in different environments: 1.10.8 and 3.1.7
PASSED
tests/test_discover.py::test_discover_nested PASSED
tests/test_pipcompilemulti.py::test_fix_compatible_pin PASSED
tests/test_pipcompilemulti.py::test_no_fix_incompatible_pin PASSED
tests/test_pipcompilemulti.py::test_pin_is_ommitted_if_set_to_ignore PASSED
tests/test_pipcompilemulti.py::test_post_releases_are_kept_by_default PASSED
tests/test_pipcompilemulti.py::test_forbid_post_releases PASSED
tests/test_pipcompilemulti.py::test_parse_references[base.in-refs0] PASSED
tests/test_pipcompilemulti.py::test_parse_references[test.in-refs1] PASSED
tests/test_pipcompilemulti.py::test_parse_references[local.in-refs2] PASSED
tests/test_pipcompilemulti.py::test_split_header PASSED
tests/test_pipcompilemulti.py::test_concatenation PASSED
tests/test_pipcompilemulti.py::test_parse_hashes_with_comment PASSED
tests/test_pipcompilemulti.py::test_parse_hashes_without_comment PASSED
tests/test_pipcompilemulti.py::test_serialize_hashes PASSED
tests/test_pipcompilemulti.py::test_reference_cluster PASSED
tests/test_pipcompilemulti.py::test_parse_vcs_dependencies PASSED
tests/test_pipcompilemulti.py::test_merged_packages_raise_for_conflict
-------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------
ERROR    pip-compile-multi:utils.py:79 Package x was resolved to different versions in different environments: 2 and 1
PASSED
tests/test_pipcompilemulti.py::test_fix_pin_detects_version_conflict
-------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------
ERROR    pip-compile-multi:environment.py:218 Package x was resolved to different versions in different environments: 2 and 1
PASSED
tests/test_upgrade_feature.py::test_upgrade_package_disables_upgrade PASSED
tests/test_utils.py::test_recursive_refs PASSED

====================================================================================================== 49 passed in 114.33s (0:01:54) ======================================================================================================
```