### PR TITLE
Move env limiting to features controller

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 2.4.3 (Unreleased)
 ------------------
 
-* Prioritize URL depedencies when parsing to enable URLs with version pins inside
+* Prioritize URL depedencies when parsing to enable URLs that have version pins.
+* Make ``--autoresolve`` work correctly with ``-t`` and ``-n`` options.
 
 2.4.2 (2021-09-01)
 ------------------

--- a/pipcompilemulti/actions.py
+++ b/pipcompilemulti/actions.py
@@ -15,8 +15,9 @@ logger = logging.getLogger("pip-compile-multi")
 
 def recompile():
     """Compile requirements files for all environments."""
-    env_confs = discover(FEATURES.compose_input_file_path('*'))
-    FEATURES.on_discover(env_confs)
+    env_confs = FEATURES.on_discover(
+        discover(FEATURES.compose_input_file_path('*'))
+    )
     deduplicator = PackageDeduplicator()
     deduplicator.on_discover(env_confs)
     sink_in_path = FEATURES.sink_in_path()
@@ -33,8 +34,6 @@ def recompile():
 def compile_topologically(env_confs, deduplicator):
     """Compile environments in topological order of reference."""
     for conf in env_confs:
-        if not FEATURES.included(conf['in_path']):
-            continue
         env = Environment(in_path=conf['in_path'], deduplicator=deduplicator)
         if env.maybe_create_lockfile():
             # Only munge lockfile if it was written.

--- a/pipcompilemulti/features/controller.py
+++ b/pipcompilemulti/features/controller.py
@@ -113,12 +113,17 @@ class FeaturesController:
         return self.compatible.constraint(package_name)
 
     def on_discover(self, env_confs):
-        """Configure features with a list of discovered environments."""
-        self.add_hashes.on_discover(env_confs)
+        """Configure features with a list of discovered environments.
+
+        Returns a new possibly shorter env list.
+        """
+        self.upgrade_selected.reset()
         self.limit_envs.on_discover(env_confs)
         self.limit_in_paths.on_discover(env_confs)
-        self.upgrade_selected.reset()
-        self.autoresolve.on_discover(env_confs)
+        limited_env_confs = [env for env in env_confs if self.included(env['in_path'])]
+        self.add_hashes.on_discover(limited_env_confs)
+        self.autoresolve.on_discover(limited_env_confs)
+        return limited_env_confs
 
     def affected(self, in_path):
         """Whether environment is affected by upgrade command."""


### PR DESCRIPTION
Allow `--autoresolve` to work only on a limited set of envs.