### PR TITLE
Use --autoresolve for pip-compile-multi

### DIFF
--- a/pipcompilemulti/cli_v2.py
+++ b/pipcompilemulti/cli_v2.py
@@ -68,6 +68,7 @@ def run_configurations(callback, sections_reader):
         'base_dir': 'requirements',
         'in_ext': 'in',
         'out_ext': 'txt',
+        'autoresolve': True,
     }
     sections = sections_reader()
     if sections is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,12 +19,12 @@ replace = __version__ = '{new_version}'
 
 [requirements:Python 3]
 python = 3.6
-include_names = local, testwin
+include_names = local
 
 [requirements:Python 3 hash]
 python = 3.6
-include_names = local, testwin
-add_hashes = local, testwin
+include_names = local
+add_hashes = local
 in_ext = txt
 out_ext = hash
 

--- a/tests/test_cli_v1.py
+++ b/tests/test_cli_v1.py
@@ -1,6 +1,5 @@
-"""End to end tests for CLI v2"""
+"""End to end tests for CLI v1"""
 
-import sys
 from click.testing import CliRunner
 import pytest
 from pipcompilemulti.cli_v1 import cli
@@ -22,21 +21,17 @@ def test_v1_command_exits_with_zero(command):
     """Run pip-compile-multi on self.
 
     pip-compile-multi --only-name local --generate-hashes local \
-            --in-ext txt --out-ext hash --use-cache
+            --in-ext txt --out-ext hash --use-cache \
+            --autoresolve
     """
-    local = (
-        'local'
-        if sys.version_info[0] >= 3
-        else 'local27'
-    )
     runner = CliRunner()
-    parameters = ['--only-name', local]
-    parameters.append(command)
+    parameters = [command, '--autoresolve', '--only-name', 'local', '--use-cache']
     result = runner.invoke(cli, parameters)
-    parameters[:0] = ['--generate-hashes', local,
-                      '--in-ext', 'txt',
-                      '--out-ext', 'hash',
-                      '--use-cache']
+    parameters.extend([
+        '--generate-hashes', 'local',
+        '--in-ext', 'txt',
+        '--out-ext', 'hash',
+    ])
     result = runner.invoke(cli, parameters)
     assert result.exit_code == 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,8 @@ basepython = python3.6
 usedevelop = True
 deps = -rrequirements/base.txt
 commands =
-    pip-compile-multi
-    pip-compile-multi -g local -i txt -o hash --allow-unsafe
+    pip-compile-multi --autoresolve -t requirements/local.in
+    pip-compile-multi -t requirements/local.txt -g local -i txt -o hash --allow-unsafe
 
 [pytest]
 addopts = -vvvs --doctest-modules


### PR DESCRIPTION
`flake8` added `<4.3` constraint on `importlib-metadata`, which caused a version conflict, because 
`importlib-metadata` comes from `click` in `base.in`, but `flake8` is only added in `local.txt`.
`--autoresolve` is designed to cope with exactly this problem, so I'm enabling it both in `tox -e upgrade` and unit tests.