### PR TITLE
Add no-build-isolation feature

### DIFF
--- a/pipcompilemulti/features/controller.py
+++ b/pipcompilemulti/features/controller.py
@@ -19,6 +19,7 @@ from .autoresolve import Autoresolve
 from .skip_constraint_comments import SkipConstraintComments
 from .live_output import LiveOutput
 from .extra_index_url import ExtraIndexUrl
+from .no_build_isolation import NoBuildIsolation
 
 
 class FeaturesController:
@@ -44,6 +45,7 @@ class FeaturesController:
         self.skip_constraint_comments = SkipConstraintComments()
         self.live_output = LiveOutput()
         self.extra_index_url = ExtraIndexUrl()
+        self.no_build_isolation = NoBuildIsolation()
         self._features = [
             self.annotate_index,
             self.use_cache,
@@ -63,6 +65,7 @@ class FeaturesController:
             self.skip_constraint_comments,
             self.live_output,
             self.extra_index_url,
+            self.no_build_isolation,
         ]
 
     def bind(self, command):

--- a/pipcompilemulti/features/no_build_isolation.py
+++ b/pipcompilemulti/features/no_build_isolation.py
@@ -1,0 +1,21 @@
+from .base import ClickOption
+from .forward import ForwardOption
+
+
+class NoBuildIsolation(ForwardOption):
+    """
+    Enable isolation when building a modern source distribution.
+    Build dependencies specified by PEP 518 must be already installed if build isolation is disabled.
+    """
+
+    OPTION_NAME = 'no_build_isolation'
+    CLICK_OPTION = ClickOption(
+        long_option='--no-build-isolation',
+        is_flag=True,
+        default=False,
+        help_text=(
+            'Enable isolation when building a modern source distribution. '
+            'Build dependencies specified by PEP 518 must be already installed if build isolation is disabled.'
+        ),
+    )
+    enabled_pin_options = ['--no-build-isolation']

--- a/tests/test_cli_v1.py
+++ b/tests/test_cli_v1.py
@@ -16,7 +16,7 @@ def requirements_dir():
 
 
 @pytest.mark.parametrize('command', ['--no-upgrade', '--upgrade',
-                                     '--upgrade-package=pip-tools'])
+                                     '--upgrade-package=pip-tools', '--no-build-isolation'])
 def test_v1_command_exits_with_zero(command):
     """Run pip-compile-multi on self.
 


### PR DESCRIPTION
Adds a feature to enable the `pip` / `pip-compile` argument `--no-build-isolation`. Also updates a unit test to call this feature.

I have a use case that requires disabling build isolation that I'd like to use `pip-compile-multi` for.