### PR TITLE
Add version sanitization regex

### DIFF
--- a/pipcompilemulti/dependency.py
+++ b/pipcompilemulti/dependency.py
@@ -103,6 +103,7 @@ class Dependency(object):  # pylint: disable=too-many-instance-attributes
         if regular:
             self.package = regular.group('package')
             self.version = regular.group('version').strip()
+            self.version = re.sub(r"\.(0)\d+", "", self.version)  # strip leading zeros
             self.hashes = (regular.group('hashes') or '').strip()
             self.comment = (regular.group('comment') or '').rstrip()
             self.comment_span = self._adjust_span(regular.span('comment'), regular)

--- a/pipcompilemulti/dependency.py
+++ b/pipcompilemulti/dependency.py
@@ -75,6 +75,8 @@ class Dependency(object):  # pylint: disable=too-many-instance-attributes
         r'(?P<url>\S+)'
         r'(?P<comment>(?:\s*#.*)+)?$'
     )
+    # Example: 2022.02.1 -> 2022.2.1
+    RE_IGNORED_ZEROS = re.compile(r"(?<=\.)0+(?=\d)")
 
     def __init__(self, line):
         self.is_vcs = False
@@ -102,8 +104,7 @@ class Dependency(object):  # pylint: disable=too-many-instance-attributes
         regular = self.RE_DEPENDENCY.match(line)
         if regular:
             self.package = regular.group('package')
-            _version = regular.group('version').strip()
-            self.version = re.sub(r"(?<=\.)0+(?=\d+)", "", _version)  # strip leading zeros
+            self.version = self.RE_IGNORED_ZEROS.sub("", regular.group('version').strip())
             self.hashes = (regular.group('hashes') or '').strip()
             self.comment = (regular.group('comment') or '').rstrip()
             self.comment_span = self._adjust_span(regular.span('comment'), regular)

--- a/pipcompilemulti/dependency.py
+++ b/pipcompilemulti/dependency.py
@@ -103,7 +103,7 @@ class Dependency(object):  # pylint: disable=too-many-instance-attributes
         if regular:
             self.package = regular.group('package')
             _version = regular.group('version').strip()
-            self.version = re.sub(r"\.(0)\d+", "", _version)  # strip leading zeros
+            self.version = re.sub(r"(?<=\.)0+(?=\d+)", "", _version)  # strip leading zeros
             self.hashes = (regular.group('hashes') or '').strip()
             self.comment = (regular.group('comment') or '').rstrip()
             self.comment_span = self._adjust_span(regular.span('comment'), regular)

--- a/pipcompilemulti/dependency.py
+++ b/pipcompilemulti/dependency.py
@@ -102,8 +102,8 @@ class Dependency(object):  # pylint: disable=too-many-instance-attributes
         regular = self.RE_DEPENDENCY.match(line)
         if regular:
             self.package = regular.group('package')
-            self.version = regular.group('version').strip()
-            self.version = re.sub(r"\.(0)\d+", "", self.version)  # strip leading zeros
+            _version = regular.group('version').strip()
+            self.version = re.sub(r"\.(0)\d+", "", _version)  # strip leading zeros
             self.hashes = (regular.group('hashes') or '').strip()
             self.comment = (regular.group('comment') or '').rstrip()
             self.comment_span = self._adjust_span(regular.span('comment'), regular)

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -101,3 +101,21 @@ def test_parse_at_url_notation():
          "dep @ https://site.com/path\n"
          "  # via -r pkg"
     )
+
+
+def test_sanitize_package_version():
+    """Simple package name with a single "via" reference."""
+    dependency = Dependency("gcsfs==2022.02.1    # via pkg")
+    assert vars(dependency) == {
+        "is_at": False,
+        "is_vcs": False,
+        "comment": "    # via pkg",
+        "comment_span": (16, 29),
+        "hashes": "",
+        "package": "gcsfs",
+        "valid": True,
+        "version": "2022.2.1",
+        "line": "gcsfs==2022.02.1    # via pkg",
+    }
+    OPTIONS[FEATURES.skip_constraint_comments.OPTION_NAME] = True
+    assert dependency.serialize() == "gcsfs==2022.2.1           # via pkg"

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -104,7 +104,7 @@ def test_parse_at_url_notation():
 
 
 def test_sanitize_package_version():
-    """Simple package name with a single "via" reference."""
+    """Simple package name with leading zeros in the version, with a single "via" reference."""
     dependency = Dependency("gcsfs==2022.02.1    # via pkg")
     assert vars(dependency) == {
         "is_at": False,


### PR DESCRIPTION
Took a stab at addressing #304. Adds a simple regex substitution to sanitize leading zeros out of dependency versions.

Todo:
- [x] add/update unit test(s)