### PR TITLE
Set correct license classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Environment :: Console',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
As far as I can see, pip-compile-multi was always MIT licensed, but the classifier in setup.py was incorrectly set to "BSD".

This also shows up incorrectly [on PyPI](https://pypi.org/project/pip-compile-multi/):
![image](https://user-images.githubusercontent.com/7095678/162168768-f83dd2e3-7b11-4aff-83bc-084a92fd2674.png)
![image](https://user-images.githubusercontent.com/7095678/162168865-a0d47049-5967-4c42-b034-66009d9a27ff.png)


This PR updates `setup.py` to use the correct classifier from https://pypi.org/classifiers/

Thanks for this great tool, I like it a lot! 👍 