### PR TITLE
Use constraints when toposorting environments

### DIFF
--- a/pipcompilemulti/environment.py
+++ b/pipcompilemulti/environment.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("pip-compile-multi")
 class Environment(object):
     """requirements file"""
 
-    RE_REF = re.compile(r'^(?:-r|--requirement|-c|--constraint)\s*(?P<path>\S+).*$')
+    RE_REF = re.compile(r'^(?:-r|--requirement|-c|--constraint)\s*(?P<path>\S+)$')
     RE_COMMENT = re.compile(r'^\s*#.*$')
 
     def __init__(self, in_path, deduplicator=None):

--- a/pipcompilemulti/environment.py
+++ b/pipcompilemulti/environment.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("pip-compile-multi")
 class Environment(object):
     """requirements file"""
 
-    RE_REF = re.compile(r'^(?:-r|--requirement)\s*(?P<path>\S+).*$')
+    RE_REF = re.compile(r'^(?:-r|--requirement|-c|--constraint)\s*(?P<path>\S+).*$')
     RE_COMMENT = re.compile(r'^\s*#.*$')
 
     def __init__(self, in_path, deduplicator=None):


### PR DESCRIPTION
Note: I'm not 100% sure this is right.

I have a use case where I need to have my dependencies defined in multiple files. When locking them together, I want to constrain certain files by the locked dependency files "upstream" in the dependency topology. These aren't additional requirements, they're just constraints, so I don't want to use the `-r` flag. Does that make sense?

Currently, the `-c` flag is recognized when locking the files, but isn't used when constructing the dependency DAG/topology (determining the order in which files are locked).

~In other words, what I want to happen is this:~

~`B.in` is constrained by `A.txt` (which is the lockfile of `A.in`, and may not exist if this is the first time PCM is executed). So PCM should first lock `A.in`, thereby generating/updating `A.txt`. Then it should lock `B.in` to generate/update `B.txt`.~