### PR TITLE
Change `-e` to `-r` in `pip install -r requirements/test.in`

### DIFF
--- a/docs/why.rst
+++ b/docs/why.rst
@@ -103,7 +103,7 @@ Now installation command is
 
 .. code-block:: shell
 
-    pip install -e requirements/test.in
+    pip install -r requirements/test.in
 
 For one single time (exceptionally to show how unacceptable is this task)
 let's manually compose ``requirements/test.txt``.


### PR DESCRIPTION
I think it should be `r` here, shouldn't it?

Cheers