### PR TITLE
Extract util to simplify using test data without locally modifying it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
 """Pytest configuration."""
 
+import shutil
+import pathlib
+import os.path
+import tempfile
+import contextlib
+
 import pytest
 from pipcompilemulti.options import OPTIONS
 
@@ -8,3 +14,19 @@ from pipcompilemulti.options import OPTIONS
 def wipe_options():
     """Reset global OPTIONS dictionary before every test."""
     OPTIONS.clear()
+
+
+@pytest.fixture()
+def test_data_tmpdir():
+    """Copy the requested test data to a temporary directory."""
+
+    with contextlib.ExitStack() as stack:
+
+        def copy(test_data_name):
+            source = os.path.join('tests', test_data_name)
+            tmp_dir = stack.enter_context(tempfile.TemporaryDirectory())
+            os.rmdir(tmp_dir)
+            shutil.copytree(source, tmp_dir)
+            return pathlib.Path(tmp_dir)
+
+        yield copy

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,22 +1,24 @@
 """End to end tests checking conflicts detection"""
 
-import os
 import pytest
 from click.testing import CliRunner
 from pipcompilemulti.cli_v1 import cli
 
 
 @pytest.mark.parametrize('conflict', ['merge', 'ref'])
-def test_conflict_detected(conflict):
+def test_conflict_detected(test_data_tmpdir, conflict):
     """Following types of version conflicts are detected:
 
     1. Two files have different version and referenced from the third file.
     2. File adds new constraint on package from referenced file.
     """
+
+    tmp_dir = test_data_tmpdir('conflicting-in-' + conflict)
+
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ['--directory', os.path.join('tests', 'conflicting-in-' + conflict)],
+        ['--directory', str(tmp_dir)],
     )
     assert result.exit_code == 1
     assert 'Please add constraints' in str(result.exception)


### PR DESCRIPTION
This makes it easier to use test data stored in the repo without the tests actually modifying the repo content. While this makes it slightly harder to see the changes that a test failure made, it avoids creating unexpected changes to the developer's working environment when they run the tests.