### PR TITLE
Fixes #516 - TypeError is not triggered when sections is None

### DIFF
--- a/pipcompilemulti/cli_v2.py
+++ b/pipcompilemulti/cli_v2.py
@@ -77,6 +77,7 @@ def run_configurations(callback, sections_reader, **overrides):
         logger.info("Configuration not found in pyproject.toml "
                     "or one of .ini files. Running with default settings")
         recompile()
+        return []
     elif sections == []:
         logger.info("Configuration does not match current runtime. "
                     "Exiting")


### PR DESCRIPTION
In case sections is `None` recompile requirements, and get out since result will always be empty list in this case