### PR TITLE
Add support for --find-links option #554

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -34,6 +34,8 @@ In ``pyproject.toml`` prefix section name with ``tool.requirements``, for exampl
 
 .. automodule:: pipcompilemulti.features.emit_trusted_host
 
+.. automodule:: pipcompilemulti.features.emit_find_links
+
 .. automodule:: pipcompilemulti.features.autoresolve
 
 .. automodule:: pipcompilemulti.features.backtracking

--- a/pipcompilemulti/features/controller.py
+++ b/pipcompilemulti/features/controller.py
@@ -10,6 +10,7 @@ from .backtracking import Backtracking
 from .base_dir import BaseDir
 from .build_isolation import BuildIsolation
 from .compatible import Compatible
+from .emit_find_links import EmitFindLinks
 from .emit_trusted_host import EmitTrustedHost
 from .extra_index_url import ExtraIndexUrl
 from .file_extensions import InputExtension, OutputExtension
@@ -38,6 +39,7 @@ class FeaturesController:
         self.base_dir = BaseDir()
         self.build_isolation = BuildIsolation()
         self.compatible = Compatible()
+        self.emit_find_links = EmitFindLinks()
         self.emit_trusted_host = EmitTrustedHost()
         self.extra_index_url = ExtraIndexUrl()
         self.forbid_post = ForbidPost()
@@ -61,6 +63,7 @@ class FeaturesController:
             self.base_dir,
             self.build_isolation,
             self.compatible,
+            self.emit_find_links,
             self.emit_trusted_host,
             self.extra_index_url,
             self.forbid_post,
@@ -117,6 +120,7 @@ class FeaturesController:
         options.extend(self.add_hashes.pin_options(in_path))
         options.extend(self.annotate_index.pin_options())
         options.extend(self.build_isolation.pin_options())
+        options.extend(self.emit_find_links.pin_options())
         options.extend(self.extra_index_url.pin_options())
         options.extend(self.upgrade_all.pin_options())
         options.extend(self.upgrade_selected.pin_options())

--- a/pipcompilemulti/features/emit_find_links.py
+++ b/pipcompilemulti/features/emit_find_links.py
@@ -1,0 +1,53 @@
+"""
+.. _emit_find_links:
+
+Add find-links annotation
+=========================
+
+Control addition of ``--find-links`` options to the output files.
+Corresponds to ``pip-compile``'s and ``uv pip compile``'s
+``--emit-find-links / --no-emit-find-links`` flag.
+
+The URL can be defined in the input file as in this example:
+
+.. code-block:: text
+
+    --find-links=https://download.pytorch.org/whl/torch_stable.html
+    torch
+
+By default, ``--find-links`` entries from input files are preserved
+in the generated output files.
+Pass ``--no-emit-find-links`` to strip them.
+
+.. code-block:: text
+
+    --emit-find-links / --no-emit-find-links
+                                    Add find-links to generated files
+                                    (default true)
+
+In configuration file, use ``emit_find_links`` option::
+
+    [requirements]
+    emit_find_links = False
+
+Note: ``uv pip compile`` strips ``--find-links`` entries by default,
+so this flag is forwarded to both ``pip-tools`` and ``uv`` backends
+to keep behavior consistent.
+"""
+
+from .base import ClickOption
+from .forward import ForwardOption
+
+
+class EmitFindLinks(ForwardOption):
+    """Optionally add the find-links entries to the generated files."""
+
+    OPTION_NAME = 'emit_find_links'
+    CLICK_OPTION = ClickOption(
+        long_option='--emit-find-links/--no-emit-find-links',
+        is_flag=True,
+        default=True,
+        help_text="Add find-links entries to generated files (default true)",
+    )
+    enabled_pin_options = ['--emit-find-links']
+    disabled_pin_options = ['--no-emit-find-links']

--- a/tests/test_pipcompilemulti.py
+++ b/tests/test_pipcompilemulti.py
@@ -13,6 +13,7 @@ from pipcompilemulti.dependency import Dependency
 from pipcompilemulti.options import OPTIONS
 from pipcompilemulti.deduplicate import PackageDeduplicator
 from pipcompilemulti.utils import merged_packages, reference_cluster
+from pipcompilemulti.features import FEATURES
 from pipcompilemulti.features.header import DEFAULT_HEADER
 
 
@@ -266,3 +267,35 @@ def test_fix_pin_detects_version_conflict():
     assert ignored_pin is None
     with pytest.raises(RuntimeError):
         env.fix_pin('x==2')
+
+
+def test_emit_find_links_enabled_by_default():
+    """By default find-links entries are preserved in generated files."""
+    assert FEATURES.emit_find_links.pin_options() == ['--emit-find-links']
+
+
+def test_emit_find_links_disabled():
+    """When explicitly disabled, --no-emit-find-links is forwarded."""
+    with mock.patch.dict(OPTIONS, {'emit_find_links': False}):
+        assert FEATURES.emit_find_links.pin_options() == ['--no-emit-find-links']
+
+
+def test_emit_find_links_forwarded_in_pip_tools_mode():
+    """Pin options include --emit-find-links when using pip-tools backend."""
+    FEATURES.on_discover([])
+    with mock.patch.dict(OPTIONS, {'uv': False}):
+        assert '--emit-find-links' in FEATURES.pin_options('any.in')
+
+
+def test_emit_find_links_forwarded_in_uv_mode():
+    """Pin options include --emit-find-links when using uv backend."""
+    FEATURES.on_discover([])
+    with mock.patch.dict(OPTIONS, {'uv': True}):
+        assert '--emit-find-links' in FEATURES.pin_options('any.in')
+
+
+def test_no_emit_find_links_forwarded_in_uv_mode():
+    """--no-emit-find-links is forwarded to uv backend when disabled."""
+    FEATURES.on_discover([])
+    with mock.patch.dict(OPTIONS, {'uv': True, 'emit_find_links': False}):
+        assert '--no-emit-find-links' in FEATURES.pin_options('any.in')


### PR DESCRIPTION
## Summary
Added support for `--emit-find-links`/`--no-emit-find-links` arguments which keep the `--find-links` setting in the compiled txt files.

Resolves #554